### PR TITLE
Allow users to select zoom levels

### DIFF
--- a/HORUS/SOURCES/SRC/SCRIPTS/TOOLS/Yaapu Maps.lua
+++ b/HORUS/SOURCES/SRC/SCRIPTS/TOOLS/Yaapu Maps.lua
@@ -198,7 +198,9 @@ example {"center pane layout:", TYPECOMBO, "CPANE", 1, { "hud","radar" }, { 1, 2
 
 --]]--
 local menuItems = {
-  {"map zoom level:", 0, "MAPZ", -2, -2, 17,nil,0,1 },
+  {"map zoom level 1:", 0, "MAPZ", -2, -2, 17,nil,0,1 },
+  {"map zoom level 2:", 0, "MAPZMID", -1, -2, 17,nil,0,1 },
+  {"map zoom level 3:", 0, "MAPZHIGH", 0, -2, 17,nil,0,1 },
   {"map type:", 1, "MAPT", 1, { "satellite", "map", "terrain" }, { "sat_tiles", "tiles", "ter_tiles" } },
   {"map grid lines:", 1, "MAPG", 1, { "yes", "no" }, { true, false } },
   {"map trail dots:", 0, "MAPTD", 10, 5, 50,nil,0,1 },
@@ -258,6 +260,8 @@ local function applyConfigValues(conf)
   end
   
   conf.mapZoomLevel = getMenuItemByName(menuItems,"MAPZ")
+  conf.mapZoomLevelMid = getMenuItemByName(menuItems,"MAPZMID")
+  conf.mapZoomLevelHigh = getMenuItemByName(menuItems,"MAPZHIGH")
   conf.mapType = getMenuItemByName(menuItems,"MAPT")
   conf.mapTrailDots = getMenuItemByName(menuItems,"MAPTD")
   

--- a/HORUS/SOURCES/SRC/SCRIPTS/YAAPU/mapsconfig.lua
+++ b/HORUS/SOURCES/SRC/SCRIPTS/YAAPU/mapsconfig.lua
@@ -198,7 +198,9 @@ example {"center pane layout:", TYPECOMBO, "CPANE", 1, { "hud","radar" }, { 1, 2
 
 --]]--
 local menuItems = {
-  {"map zoom level:", 0, "MAPZ", -2, -2, 17,nil,0,1 },
+  {"map zoom level 1:", 0, "MAPZ", -2, -2, 17,nil,0,1 },
+  {"map zoom level 2:", 0, "MAPZ-MID", -2, -2, 17,nil,0,1 },
+  {"map zoom level 3:", 0, "MAPZ-HIGH", -2, -2, 17,nil,0,1 },
   {"map type:", 1, "MAPT", 1, { "satellite", "map", "terrain" }, { "sat_tiles", "tiles", "ter_tiles" } },
   {"map grid lines:", 1, "MAPG", 1, { "yes", "no" }, { true, false } },
   {"map trail dots:", 0, "MAPTD", 10, 5, 50,nil,0,1 },
@@ -258,6 +260,8 @@ local function applyConfigValues(conf)
   end
   
   conf.mapZoomLevel = getMenuItemByName(menuItems,"MAPZ")
+  conf.mapZoomLevelMid = getMenuItemByName(menuItems,"MAPZ-MID")
+  conf.mapZoomLevelHigh = getMenuItemByName(menuItems,"MAPZ-HIGH")
   conf.mapType = getMenuItemByName(menuItems,"MAPT")
   conf.mapTrailDots = getMenuItemByName(menuItems,"MAPTD")
   

--- a/HORUS/SOURCES/SRC/SCRIPTS/YAAPU/mapsconfig.lua
+++ b/HORUS/SOURCES/SRC/SCRIPTS/YAAPU/mapsconfig.lua
@@ -199,8 +199,8 @@ example {"center pane layout:", TYPECOMBO, "CPANE", 1, { "hud","radar" }, { 1, 2
 --]]--
 local menuItems = {
   {"map zoom level 1:", 0, "MAPZ", -2, -2, 17,nil,0,1 },
-  {"map zoom level 2:", 0, "MAPZ-MID", -2, -2, 17,nil,0,1 },
-  {"map zoom level 3:", 0, "MAPZ-HIGH", -2, -2, 17,nil,0,1 },
+  {"map zoom level 2:", 0, "MAPZMID", -1, -2, 17,nil,0,1 },
+  {"map zoom level 3:", 0, "MAPZHIGH", 0, -2, 17,nil,0,1 },
   {"map type:", 1, "MAPT", 1, { "satellite", "map", "terrain" }, { "sat_tiles", "tiles", "ter_tiles" } },
   {"map grid lines:", 1, "MAPG", 1, { "yes", "no" }, { true, false } },
   {"map trail dots:", 0, "MAPTD", 10, 5, 50,nil,0,1 },
@@ -260,8 +260,8 @@ local function applyConfigValues(conf)
   end
   
   conf.mapZoomLevel = getMenuItemByName(menuItems,"MAPZ")
-  conf.mapZoomLevelMid = getMenuItemByName(menuItems,"MAPZ-MID")
-  conf.mapZoomLevelHigh = getMenuItemByName(menuItems,"MAPZ-HIGH")
+  conf.mapZoomLevelMid = getMenuItemByName(menuItems,"MAPZMID")
+  conf.mapZoomLevelHigh = getMenuItemByName(menuItems,"MAPZHIGH")
   conf.mapType = getMenuItemByName(menuItems,"MAPT")
   conf.mapTrailDots = getMenuItemByName(menuItems,"MAPTD")
   

--- a/HORUS/SOURCES/SRC/WIDGETS/YaapuMaps/main.lua
+++ b/HORUS/SOURCES/SRC/WIDGETS/YaapuMaps/main.lua
@@ -377,10 +377,10 @@ utils.getHomeFromAngleAndDistance = function(telemetry)
   d be distance (m),
   R as radius of Earth (m),
   Ad be the angular distance i.e d/R and
-  ? be the bearing in deg
+  θ be the bearing in deg
   
-  la2 =  asin(sin la1 * cos Ad  + cos la1 * sin Ad * cos ?), and
-  lo2 = lo1 + atan2(sin ? * sin Ad * cos la1 , cos Ad – sin la1 * sin la2)
+  la2 =  asin(sin la1 * cos Ad  + cos la1 * sin Ad * cos θ), and
+  lo2 = lo1 + atan2(sin θ * sin Ad * cos la1 , cos Ad – sin la1 * sin la2)
 --]]  if telemetry.lat == nil or telemetry.lon == nil then
     return nil,nil
   end
@@ -469,7 +469,7 @@ local function calcHomeDirection(gpsPos)
   if gpsHome == false then
     return false
   end
-  -- Formula:	? = atan2( sin ?? · cos f2 , cos f1 · sin f2 - sin f1 · cos f2 · cos ?? )
+  -- Formula:	θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
   local lat2 = math.rad(gpsHome.lat)
   local lon2 = math.rad(gpsHome.lon)
   local lat1 = math.rad(gpsPos.lat)

--- a/HORUS/SOURCES/SRC/WIDGETS/YaapuMaps/main.lua
+++ b/HORUS/SOURCES/SRC/WIDGETS/YaapuMaps/main.lua
@@ -377,10 +377,10 @@ utils.getHomeFromAngleAndDistance = function(telemetry)
   d be distance (m),
   R as radius of Earth (m),
   Ad be the angular distance i.e d/R and
-  θ be the bearing in deg
+  ? be the bearing in deg
   
-  la2 =  asin(sin la1 * cos Ad  + cos la1 * sin Ad * cos θ), and
-  lo2 = lo1 + atan2(sin θ * sin Ad * cos la1 , cos Ad – sin la1 * sin la2)
+  la2 =  asin(sin la1 * cos Ad  + cos la1 * sin Ad * cos ?), and
+  lo2 = lo1 + atan2(sin ? * sin Ad * cos la1 , cos Ad – sin la1 * sin la2)
 --]]  if telemetry.lat == nil or telemetry.lon == nil then
     return nil,nil
   end
@@ -469,7 +469,7 @@ local function calcHomeDirection(gpsPos)
   if gpsHome == false then
     return false
   end
-  -- Formula:	θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
+  -- Formula:	? = atan2( sin ?? · cos f2 , cos f1 · sin f2 - sin f1 · cos f2 · cos ?? )
   local lat2 = math.rad(gpsHome.lat)
   local lon2 = math.rad(gpsHome.lon)
   local lat1 = math.rad(gpsPos.lat)
@@ -746,7 +746,7 @@ utils.getMapZoomLevel = function(myWidget,conf,status)
       return conf.mapZoomLevelHigh
     end
     
-    if chValue > - 600 and chValue < 600 then
+    if chValue > -600 and chValue < 600 then
       return conf.mapZoomLevelMid
     end
   end

--- a/HORUS/SOURCES/SRC/WIDGETS/YaapuMaps/main.lua
+++ b/HORUS/SOURCES/SRC/WIDGETS/YaapuMaps/main.lua
@@ -303,6 +303,8 @@ local currentPage = 0
 local conf = {
   mapType = "sat_tiles",
   mapZoomLevel = -2,
+  mapZoomLevelMid = -1,
+  mapZoomLevelHigh = 0,
   enableMapGrid = true,
   mapToggleChannelId = nil,
   mapTrailDots = 10,
@@ -741,11 +743,11 @@ utils.getMapZoomLevel = function(myWidget,conf,status)
   
   if conf.mapToggleChannelId > -1 then
     if chValue >= 600 then
-      return conf.mapZoomLevel + 2
+      return conf.mapZoomLevelHigh
     end
     
     if chValue > - 600 and chValue < 600 then
-      return conf.mapZoomLevel + 1
+      return conf.mapZoomLevelMid
     end
   end
   return conf.mapZoomLevel


### PR DESCRIPTION
This change allows the users to select the zoom levels in the configuration file. For example, zoom levels -1, 1, and 4. They no longer need to be linear.

https://youtu.be/PH1bHfxPpTI

Fixes #18 